### PR TITLE
Remove exit and dtor calls after ModelicaError

### DIFF
--- a/Resources/Include/MDDCANMessage.h
+++ b/Resources/Include/MDDCANMessage.h
@@ -151,7 +151,6 @@ void MDD_CANMessageFloatBitpacking(void* p_cANMessage, int bitStartPosition, dou
 
 	if (bitStartPosition > 32) {
 		ModelicaFormatError("MDDCANMessage: Error: Bit start position for writing IEEE float > 32 => size(float) exceeds message size!\n");
-		exit(-1);
 	}
 
 	if (byteBitOffset != 0) {
@@ -185,7 +184,6 @@ double MDD_CANMessageFloatBitunpacking(void* p_cANMessage, int bitStartPosition)
 
 	if (bitStartPosition > 32) {
 		ModelicaFormatError("MDDCANMessage: Error: Bit start position for reading IEEE float > 32 => size(float) exceeds message size!\n");
-		exit(-1);
 	}
 
 	if (byteBitOffset != 0) {

--- a/Resources/Include/MDDComedi.h
+++ b/Resources/Include/MDDComedi.h
@@ -35,7 +35,6 @@ void* MDD_comedi_open(const char* devicename) {
   if(device == NULL) {
     ModelicaFormatError("\nMDDComedi.h: comedi_open failure (%s)\n",
                         comedi_strerror(comedi_errno()) );
-     exit(-1);
   }
   ModelicaFormatMessage("\tOK (fd=%d).\n", comedi_fileno(device));
   ModelicaFormatMessage("           Opened comedi device fd=%d: board name=%s, driver name=%s.\n",
@@ -93,7 +92,6 @@ void MDD_comedi_dio_config(void* p_device, int subdevice, int channel, int direc
   if ( ret == -1) {
     ModelicaFormatError("MDDComedi.h: comedi_dio_config failure (%s).\n",
                         comedi_strerror(comedi_errno()) );
-    exit(-1);
   }
 }
 
@@ -128,9 +126,8 @@ int MDD_comedi_set_global_oor_behavior(int behavior) {
   enum comedi_oor_behavior oldBehavior;
 
   if (behavior >= 2) {
-    ModelicaFormatError("MDDComedi: Error, not valid argument to MDD_comedi_set_global_oor_behavior (was %d). Exiting\n",
+    ModelicaFormatError("MDDComedi: Error, not valid argument to MDD_comedi_set_global_oor_behavior (was %d).\n",
                         behavior);
-    exit(-1);
   }
 
   ModelicaFormatMessage("MDDComedi: Setting the global out-of-range behavior to %s\n",
@@ -151,8 +148,7 @@ void MDD_comedi_get_range(void* p_device, int subdevice, int channel, int range,
   comedi_range* p_range;
   p_range = comedi_get_range(device, (unsigned int)subdevice, (unsigned int)channel, (unsigned int)range);
   if (p_range == NULL) {
-    ModelicaFormatError("MDDComedi: MDD_comedi_get_range failed. exiting.\n");
-    exit(-1);
+    ModelicaFormatError("MDDComedi: MDD_comedi_get_range failed.\n");
   }
   *min = p_range->min;
   *max = p_range->max;

--- a/Resources/Include/MDDJoystick.h
+++ b/Resources/Include/MDDJoystick.h
@@ -90,7 +90,6 @@
       }
       if (fd == -1) { /* Failed again, giving up */
         ModelicaError("MDDJoystic: Neither could open /dev/input/js0, nor /dev/js0. Have the required privileges?\n");
-        exit(-1);
       }
 
       ioctl(fd, JSIOCGAXES, &nAxis);
@@ -123,7 +122,6 @@
 
     if (errno != EAGAIN) {
      	ModelicaError("\nMDDJoystic: error reading\n");
-      exit(-1);
   	}
 
     /* output axes (default to 0): */

--- a/Resources/Include/MDDRealtimeSynchronize.h
+++ b/Resources/Include/MDDRealtimeSynchronize.h
@@ -236,7 +236,6 @@ DllExport double MDD_realtimeSynchronize(double simTime, int resolution, double 
         ret = nice(20);
         if (ret == -1 && errno != 0) {
           ModelicaError("MDDRealtimeSynchronize.h: nice(20) failed\n");
-          exit(-1);
         } else {
           ModelicaFormatMessage("ProcessPriority set to %d=nice(20) \"idle\".\n", ret);
         }
@@ -246,7 +245,6 @@ DllExport double MDD_realtimeSynchronize(double simTime, int resolution, double 
         ret = nice(10);
         if (ret == -1 && errno != 0) {
           ModelicaError("MDDRealtimeSynchronize.h: nice(10) failed\n");
-          exit(-1);
         } else {
           ModelicaFormatMessage("ProcessPriority set to %d=nice(10) \"below normal\".\n", ret);
         }
@@ -256,7 +254,6 @@ DllExport double MDD_realtimeSynchronize(double simTime, int resolution, double 
         ret = nice(0);
         if (ret == -1 && errno != 0) {
           ModelicaError("MDDRealtimeSynchronize.h: nice(0) failed\n");
-          exit(-1);
         } else {
           ModelicaFormatMessage("ProcessPriority set to %d=nice(0) \"normal\".\n", ret);
         }
@@ -267,7 +264,6 @@ DllExport double MDD_realtimeSynchronize(double simTime, int resolution, double 
         ret = nice(-20);
         if (ret == -1 && errno != 0) {
           ModelicaError("MDDRealtimeSynchronize.h: nice(-20) failed\n");
-          exit(-1);
         } else {
           ModelicaFormatMessage("ProcessPriority set to %d=nice(-20) \"high\".\n", ret);
         }
@@ -279,14 +275,12 @@ DllExport double MDD_realtimeSynchronize(double simTime, int resolution, double 
          /* Lock entire address space into physical memory */
         if(mlockall(MCL_CURRENT | MCL_FUTURE) == -1) {
           ModelicaError("MDDRealtimeSynchronize.h: mlockall failed\n");
-          exit(-1);
         }
 
         /* Declare ourself as a real time task */
         param.sched_priority = MY_RT_PRIORITY;
         if(sched_setscheduler(0, SCHED_FIFO, &param) == -1) {
           ModelicaError("MDDRealtimeSynchronize.h: sched_setscheduler failed\n");
-          exit(-1);
         } else {
           ModelicaFormatMessage("ProcessPriority set to \"Realtime\"!\n");
         }
@@ -318,7 +312,6 @@ DllExport double MDD_realtimeSynchronize(double simTime, int resolution, double 
       ret = clock_gettime(CLOCK_MONOTONIC, &t_start);
       if (ret) {
 	ModelicaError("MDDRealtimeSynchronize.h: clock_gettime(..) failed\n");
-	exit(-1);
 
       }
       t_clockRealtime = t_start;
@@ -351,7 +344,6 @@ DllExport double MDD_realtimeSynchronize(double simTime, int resolution, double 
    ret = clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &t_abs, NULL);
    if (ret) {
       ModelicaError("MDDRealtimeSynchronize.h: clock_nanosleep(..) failed\n");
-      exit(1);
    }
 
    /* get value the current time of the real-time clock (should be equal to t_abs if everything is OK) */
@@ -369,7 +361,6 @@ DllExport double MDD_realtimeSynchronize(double simTime, int resolution, double 
     ret = clock_gettime(CLOCK_MONOTONIC, &ts);
     if (ret) {
         ModelicaFormatError("MDDRealtimeSynchronize.h: clock_gettime failed (%s)\n", strerror(errno));
-        exit(-1);
     }
 
     ms = ts.tv_sec*1000 + floor( (double)ts.tv_nsec/1000.0 + 0.5);

--- a/Resources/Include/MDDSerialPackager.h
+++ b/Resources/Include/MDDSerialPackager.h
@@ -104,8 +104,7 @@ DllExport void MDD_SerialPackagerSetData( void* p_package, const char * data, in
         SerialPackager* pkg = (SerialPackager*) p_package;
         memcpy(pkg->data, data,  size);
         if ( (unsigned int) size > pkg->size) {
-                ModelicaFormatError("SerialPackager: MDD_SerialPackagerSetData failed. Buffer overflow. Exiting.\n");
-                exit(-1);
+                ModelicaFormatError("SerialPackager: MDD_SerialPackagerSetData failed. Buffer overflow.\n");
         }
         pkg->size = size;
         pkg->pos = 0;
@@ -164,8 +163,7 @@ DllExport void MDD_SerialPackagerAddInteger(void* p_package, int * u, size_t n) 
 
         if (pkg->bitOffset != 0) MDD_SerialPackagerAlignToByteBoundary(pkg);
         if (pkg->pos + n*sizeof(int) > pkg->size) {
-                ModelicaFormatError("SerialPackager: MDD_SerialPackagerAddInteger failed. Buffer overflow. Exiting.+\n");
-                exit(-1);
+                ModelicaFormatError("SerialPackager: MDD_SerialPackagerAddInteger failed. Buffer overflow.\n");
         }
         memcpy(pkg->data + pkg->pos, u, n*sizeof(int));
         pkg->pos += n*sizeof(int);
@@ -186,8 +184,7 @@ DllExport void MDD_SerialPackagerGetInteger(void* p_package, int * y, int n) {
 
         if (pkg->bitOffset != 0) MDD_SerialPackagerAlignToByteBoundary(pkg);
         if (pkg->pos + n*sizeof(int) > pkg->size) {
-                ModelicaFormatError("SerialPackager: MDD_SerialPackagerGetInteger failed. Buffer overflow. Exiting.\n");
-                exit(-1);
+                ModelicaFormatError("SerialPackager: MDD_SerialPackagerGetInteger failed. Buffer overflow.\n");
         }
         memcpy(y, pkg->data + pkg->pos, n*sizeof(int));
         pkg->pos += n*sizeof(int);
@@ -206,8 +203,7 @@ DllExport void MDD_SerialPackagerAddDouble(void* p_package, double * u, size_t n
         SerialPackager* pkg = (SerialPackager*) p_package;
         if (pkg->bitOffset != 0) MDD_SerialPackagerAlignToByteBoundary(pkg);
         if (pkg->pos + n*sizeof(double) > pkg->size) {
-                ModelicaFormatError("SerialPackager: MDD_SerialPackagerAddDouble failed. Buffer overflow. Exiting.\n");
-                exit(-1);
+                ModelicaFormatError("SerialPackager: MDD_SerialPackagerAddDouble failed. Buffer overflow.\n");
         }
         memcpy(pkg->data + pkg->pos, u, n*sizeof(double));
         pkg->pos += n*sizeof(double);
@@ -226,8 +222,7 @@ DllExport void MDD_SerialPackagerGetDouble(void* p_package, double * y, int n) {
         SerialPackager* pkg = (SerialPackager*) p_package;
         if (pkg->bitOffset != 0) MDD_SerialPackagerAlignToByteBoundary(pkg);
         if (pkg->pos + n*sizeof(double) > pkg->size) {
-                ModelicaFormatError("SerialPackager: MDD_SerialPackagerGetDouble failed. Buffer overflow. Exiting.\n");
-                exit(-1);
+                ModelicaFormatError("SerialPackager: MDD_SerialPackagerGetDouble failed. Buffer overflow.\n");
         }
         memcpy(y, pkg->data + pkg->pos, n*sizeof(double));
         pkg->pos += n*sizeof(double);
@@ -247,8 +242,7 @@ DllExport void MDD_SerialPackagerAddDoubleAsFloat(void* p_package, double * u, s
         float castedDouble;
         if (pkg->bitOffset != 0) MDD_SerialPackagerAlignToByteBoundary(pkg);
         if (pkg->pos + n*sizeof(float) > pkg->size) {
-                ModelicaFormatError("SerialPackager: MDD_SerialPackagerAddDoubleAsFloat failed. Buffer overflow. Exiting.\n");
-                exit(-1);
+                ModelicaFormatError("SerialPackager: MDD_SerialPackagerAddDoubleAsFloat failed. Buffer overflow.\n");
         }
         for (i = 0; i < n; i++) {
                 castedDouble = (float) u[i];
@@ -272,8 +266,7 @@ DllExport void MDD_SerialPackagerGetFloatAsDouble(void* p_package, double * y, i
         float value;
         if (pkg->bitOffset != 0) MDD_SerialPackagerAlignToByteBoundary(pkg);
         if (pkg->pos + n*sizeof(float) > pkg->size) {
-                ModelicaFormatError("SerialPackager: MDD_SerialPackagerGetFloatAsDouble failed. Buffer overflow. Exiting.\n");
-                exit(-1);
+                ModelicaFormatError("SerialPackager: MDD_SerialPackagerGetFloatAsDouble failed. Buffer overflow.\n");
         }
         for (i = 0; i < n; i++) {
                 memcpy(&value, pkg->data + pkg->pos + i*sizeof(float), sizeof(float));
@@ -300,8 +293,7 @@ DllExport void MDD_SerialPackagerAddString(void* p_package, const char* u, int b
         if (pkg->pos + bufferSize > pkg->size) {
 		ModelicaFormatMessage("pkg->size: %d, pkg->pos+bufferSize: %d, bufferSize: %d, strlen(u): %d\n",
 				      pkg->size, pkg->pos+bufferSize, bufferSize, strlen(u));
-                ModelicaFormatError("SerialPackager: MDD_SerialPackagerAddString failed. Buffer overflow. Exiting.+\n");
-                exit(-1);
+                ModelicaFormatError("SerialPackager: MDD_SerialPackagerAddString failed. Buffer overflow.\n");
         }
         memcpy(pkg->data + pkg->pos, u, bufferSize);
         pkg->pos += bufferSize;
@@ -323,8 +315,7 @@ DllExport char* MDD_SerialPackagerGetString(void* p_package, int bufferSize) {
         if (pkg->bitOffset != 0) MDD_SerialPackagerAlignToByteBoundary(pkg);
 
         if (pkg->pos + bufferSize > pkg->size) {
-                ModelicaFormatError("SerialPackager: MDD_SerialPackagerGetString failed. Buffer overflow. Exiting.\n");
-                exit(-1);
+                ModelicaFormatError("SerialPackager: MDD_SerialPackagerGetString failed. Buffer overflow.\n");
         }
 
         for (i=pkg->pos; i < pkg->pos + bufferSize; i++) {
@@ -366,14 +357,12 @@ DllExport int MDD_SerialPackagerIntegerBitunpack(void* p_package, int bitOffset,
 			bitOffset, width, pkg->pos, pkg->bitOffset);*/
         if (width > 32) {
                 ModelicaFormatError("SerialPackager: MDD_SerialPackagerIntegerBitunpacking failed."
-                "width > 32. Exiting.\n");
-                exit(-1);
+                "width > 32.\n");
         }
 
         if ((unsigned int) bitOffset < pkg->bitOffset) {
                 ModelicaFormatError("SerialPackager: Cowardly refusing to start reading at bitOffset %d "
-                "which is lower than the current Packager bitOffset %d. Exiting.\n", bitOffset, pkg->bitOffset);
-                exit(-1);
+                "which is lower than the current Packager bitOffset %d.\n", bitOffset, pkg->bitOffset);
         }
 
         posStart = pkg->pos + bitOffset / 8;
@@ -381,7 +370,6 @@ DllExport int MDD_SerialPackagerIntegerBitunpack(void* p_package, int bitOffset,
 		/*ModelicaFormatMessage("posStart: %d, posEnd: %d, pkg->size: %d\n", posStart, posEnd, pkg->size);*/
         if (posEnd > pkg->size) {
                 ModelicaFormatError("SerialPackager: MDD_SerialPackagerIntegerBitunpacking failed. Buffer overflow.\n");
-                exit(-1);
         }
         for (j=posStart, i=0; j < posEnd; i++, j++) {
                 bits[i*8 + 0] =  pkg->data[j] & 0x01;
@@ -435,21 +423,18 @@ DllExport void MDD_SerialPackagerIntegerBitpack(void* p_package, int bitOffset, 
 
 	if (width > 32) {
 			ModelicaFormatError("SerialPackager: MDD_SerialPackagerIntegerBitpack failed."
-			"width > 32. Exiting.\n");
-			exit(-1);
+			"width > 32.\n");
 	}
 	if ((unsigned int)bitOffset < pkg->bitOffset) {
 			ModelicaFormatError("SerialPackager: Cowardly refusing to start writing at bitOffset %d "
-			"which is lower than the current Packager bitOffset %d. Exiting.\n", bitOffset, pkg->bitOffset);
-			exit(-1);
+			"which is lower than the current Packager bitOffset %d.\n", bitOffset, pkg->bitOffset);
 	}
 	if ( width < 32 && (unsigned int)data >= 0x1u << (unsigned int)width ) {
 			ModelicaFormatError("SerialPackager: Warning: Value %d can't be encoded into %d bits or is negative (no signed int support)!\n", data, width);
 	}
 	posEnd = (bitOffset + width) % 8 == 0 ? pkg->pos + (bitOffset + width) / 8 : pkg->pos + (bitOffset + width) / 8 + 1;
 	if (posEnd > pkg->size) {
-			ModelicaFormatError("SerialPackager: MDD_SerialPackagerIntegerBitpack failed. Buffer overflow. Exiting.\n");
-			exit(-1);
+			ModelicaFormatError("SerialPackager: MDD_SerialPackagerIntegerBitpack failed. Buffer overflow.\n");
 	}
 
 	memset(bits, 0, 40);
@@ -505,7 +490,6 @@ void MDD_CANMessageFloatBitpacking(void* p_cANMessage, int bitStartPosition, dou
 
         if (bitStartPosition > 32) {
                 ModelicaFormatError("MDDCANMessage: Error: Bit start position for writing IEEE float > 32 => size(float) exceeds message size!\n");
-                exit(-1);
         }
 
         if (byteBitOffset != 0) {
@@ -541,7 +525,6 @@ double MDD_CANMessageFloatBitunpacking(void* p_cANMessage, int bitStartPosition)
 
         if (bitStartPosition > 32) {
                 ModelicaFormatError("MDDCANMessage: Error: Bit start position for reading IEEE float > 32 => size(float) exceeds message size!\n");
-                exit(-1);
         }
 
         if (byteBitOffset != 0) {
@@ -588,8 +571,7 @@ void * MDD_SerialPackagerMemcpyBitRead(void* destination, const void* source, un
         int i=0,nBits=bitLength;
 
         if (bitSourceOffset > 7) {
-                ModelicaFormatError("MDDSerialPackager: bit offsets in MDD_SerialPackagerBitmemcpy greater than max value 7. Exiting.\n");
-                exit(-1);
+                ModelicaFormatError("MDDSerialPackager: bit offsets in MDD_SerialPackagerBitmemcpy greater than max value 7.\n");
         }
 
         if (bitSourceOffset == 0 && bitLength % 8 == 0) {
@@ -640,8 +622,7 @@ void * MDD_SerialPackagerMemcpyBitRead(void* destination, const void* source, un
                 dest[nBytesSrc - 1] = src[nBytesSrc - 1] << (8-bitSourceOffset)
                         | ( (src[nBytesSrc] >> (8 - ((bitLength + bitSourceOffset) % 8) ) << (8 - ((bitLength + bitSourceOffset) % 8) ) ) >> bitSourceOffset );
         } else {
-        ModelicaFormatError("MDDSerialPackager: Uups, it's not possible to get here!? Exiting.\n");
-        exit(-1);
+        ModelicaFormatError("MDDSerialPackager: Uups, it's not possible to get here!?\n");
         }
         return destination;
 }

--- a/Resources/Include/MDDSerialPort.h
+++ b/Resources/Include/MDDSerialPort.h
@@ -177,7 +177,6 @@ void * MDD_serialPortConstructor(const char * deviceName, int bufferSize, int pa
 	if (ret != 0) {
 		ModelicaFormatError("MDDSerialPort.h: pthread_mutex_init() failed (%s)\n",
 				    strerror(errno));
-		exit(1);
 	}
 
 	/* Create a serial port. */
@@ -188,7 +187,6 @@ void * MDD_serialPortConstructor(const char * deviceName, int bufferSize, int pa
 	if (serial->fd < 0) {
 		ModelicaFormatError("MDDSerialPort.h: open(..) of serial port %s failed (%s)\n", deviceName,
 				    strerror(errno));
-		exit(1);
 	}
 
 	switch (baud) {
@@ -223,7 +221,6 @@ void * MDD_serialPortConstructor(const char * deviceName, int bufferSize, int pa
 	ret = pthread_create(&serial->thread, 0, (void *) MDD_serialPortReceivingThread, serial);
 	if (ret) {
 		ModelicaFormatError("MDDSerialPort.h: pthread (MDD_serialPortReceivingThread) failed\n");
-		exit (1);
 	}
 	}
 
@@ -258,8 +255,7 @@ int MDD_serialPortReceivingThread(void * p_serial) {
                 break;
             case 1: /* new data available */
                 if(serial_poll.revents & POLLHUP) {
-                        ModelicaMessage("The serial port was disconnected. Exiting.\n");
-                        exit(1);
+                        ModelicaMessage("The serial port was disconnected.\n");
                 } else {
                     /* Lock acces to serial->msgInternal  */
             		pthread_mutex_lock(&(serial->messageMutex));
@@ -277,8 +273,7 @@ int MDD_serialPortReceivingThread(void * p_serial) {
                 }
                 break;
             default:
-                ModelicaFormatError("MDDSerialPort.h: Poll returned %d. That should not happen. Exiting\n", ret);
-                exit(1);
+                ModelicaFormatError("MDDSerialPort.h: Poll returned %d. That should not happen.\n", ret);
             }
 	}
 	return 0;
@@ -316,8 +311,6 @@ void MDD_serialPortSend(void * p_serial, const char * data, int * dataSize) {
 	if (ret < dataSize) {
 		ModelicaFormatError("MDDSerialPort.h: Expected to send: %d bytes, but was: %d\n"
 				    "sendto(..) failed (%s)\n", dataSize, ret, strerror(errno));
-		MDD_serialPortDestructor((void *) serial);
-		exit(1);
 	}
 
 }

--- a/Resources/Include/MDDSharedMemory.h
+++ b/Resources/Include/MDDSharedMemory.h
@@ -146,7 +146,6 @@ void * MDD_SharedMemoryConstructor(const char * name, int bufSize) {
   smb->semdes = sem_open(smb->semname, O_CREAT, 0644, 1);
   if(smb->semdes == SEM_FAILED) {
     ModelicaFormatError("MDDSharedMemory.h: sem_open failure (%s)\n", strerror(errno));
-    exit(-1);
   }
 
   sem_getvalue(smb->semdes, &sval);
@@ -161,14 +160,12 @@ void * MDD_SharedMemoryConstructor(const char * name, int bufSize) {
 
     if (sem_getvalue(smb->semdes, &sval)) {
       ModelicaFormatError("MDDSharedMemory.h: sem_getvalue failed (%s)\n", strerror(errno));
-      exit(-1);
     }
 
     ModelicaFormatMessage("Open shared memory object '%s' for r/w\n", smb->shmname);
     smb->shmdes = shm_open(smb->shmname, O_CREAT|O_RDWR|O_TRUNC, 0644);
     if ( smb->shmdes == -1 ) {
       ModelicaFormatError("MDDSharedMemory.h: shm_open failure (%s)", strerror(errno));
-      exit(-1);
     }
 
     /* 'truncate' shared memory object to needed size
@@ -176,7 +173,6 @@ void * MDD_SharedMemoryConstructor(const char * name, int bufSize) {
     ret = ftruncate(smb->shmdes, smb->shm_size);
     if (ret == -1){
       ModelicaFormatError("MDDSharedMemory.h: ftruncate failure (%s)\n", strerror(errno));
-      exit(-1);
     }
 
     /* Attach shared memory object to pointer (read/write) */
@@ -185,7 +181,6 @@ void * MDD_SharedMemoryConstructor(const char * name, int bufSize) {
 
     if (smb->shmptr == MAP_FAILED) {
       ModelicaFormatError("MDDSharedMemory.h: mmap failure (%s)\n", strerror(errno));
-      exit(-1);
     }
 
     /* Release the semaphore lock */

--- a/Resources/Include/MDDSocketCAN.h
+++ b/Resources/Include/MDDSocketCAN.h
@@ -111,7 +111,6 @@ void* MDD_socketCANConstructor(const char* ifname) {
   mDDSocketCAN->skt = socket(PF_CAN, SOCK_RAW, CAN_RAW);
   if(mDDSocketCAN->skt == -1) {
     ModelicaFormatError("MDDSocketCAN.h: socket failure (%s)\n", strerror(errno));
-    exit(-1);
   } else {
 	  ModelicaFormatMessage("\tOK (socket descriptor %d)\n", mDDSocketCAN->skt);
   }
@@ -122,7 +121,6 @@ void* MDD_socketCANConstructor(const char* ifname) {
   /* ifr.ifr_ifindex gets filled with that device's index: */
   if (ioctl(mDDSocketCAN->skt, SIOCGIFINDEX, &(mDDSocketCAN->ifr)) == -1) {
     ModelicaFormatError("MDDSocketCAN.h: ioctl failure (%s)\n", strerror(errno));
-    exit(-1);
   }
   ModelicaFormatMessage("\tOK\n", ifname);
 
@@ -146,7 +144,6 @@ void* MDD_socketCANConstructor(const char* ifname) {
   if (ret != 0) {
     ModelicaFormatError("MDDSocketCAN.h: pthread_mutex_init() failed (%s)\n",
 			strerror(errno));
-    exit(1);
   }
 
   /* Start dedicated receiver thread */
@@ -154,7 +151,6 @@ void* MDD_socketCANConstructor(const char* ifname) {
   ret = pthread_create(&mDDSocketCAN->thread, 0, (void *) MDD_socketCANRxThread, mDDSocketCAN);
   if (ret) {
 	  ModelicaFormatError("MDDSocketCAN.h: pthread(..) failed\n");
-	  exit (1);
   }
 
   return mDDSocketCAN;
@@ -293,9 +289,8 @@ int MDD_socketCANRxThread(MDDSocketCAN * mDDSocketCAN) {
 	 break;
        case 1: /* new data available */
 	 if(sock_poll.revents & POLLHUP) {
-	   ModelicaFormatMessage("SocketCAN (%s): The CAN socket was disconnected. Exiting.\n",
+	   ModelicaFormatMessage("SocketCAN (%s): The CAN socket was disconnected.\n",
 			   mDDSocketCAN->ifr.ifr_name);
-	   exit(1);
 	 } else {
 	   /* Receive the next CAN frame  */
 	   bytes_read = read( mDDSocketCAN->skt, &rxframe, sizeof(rxframe) );
@@ -319,8 +314,7 @@ int MDD_socketCANRxThread(MDDSocketCAN * mDDSocketCAN) {
 	   break;
 	 }
        default:
-	 ModelicaFormatError("MDDSocketCAN.h: Poll returned %d. That should not happen. Exiting\n", ret);
-	 exit(1);
+	 ModelicaFormatError("MDDSocketCAN.h: Poll returned %d. That should not happen.\n", ret);
      }
    }
    return 0;

--- a/Resources/Include/MDDSoftingCAN.h
+++ b/Resources/Include/MDDSoftingCAN.h
@@ -142,7 +142,6 @@ DllExport void* MDD_softingCANConstructor(const char* deviceName, int baudRate) 
 	ret = INIL2_initialize_channel(&channel.ulChannelHandle, (char*) channel.sChannelName);
 	if(ret) {
 		ModelicaFormatError("%s",descriptiveError(ret, "INIL2_initialize_channel"));
-		exit(ret);
 	}
 	mDDSoftingCAN->can = channel.ulChannelHandle;
 	ModelicaFormatMessage("\tOK.\n");
@@ -151,7 +150,6 @@ DllExport void* MDD_softingCANConstructor(const char* deviceName, int baudRate) 
 	ret = CANL2_reset_chip(mDDSoftingCAN->can);
 	if(ret) {
 		ModelicaFormatError("%s",descriptiveError(ret, "CANL2_reset_chip"));
-		exit(ret);
 	}
 	ModelicaFormatMessage("\tOK.\n");
 
@@ -205,12 +203,10 @@ DllExport void* MDD_softingCANConstructor(const char* deviceName, int baudRate) 
 		default:
 			ModelicaFormatError("SoftingCAN (%s): Initializing chip with not (yet) supported Baud Rate (enum value %d)\n",
 				mDDSoftingCAN->deviceName, baudRate);
-			exit(-1);
 	}
 
 	if(ret) {
 		ModelicaFormatError("%s",descriptiveError(ret, "CANL2_initialize_chip"));
-		exit(ret);
 	}
 	ModelicaFormatMessage("\tOK.\n");
 
@@ -219,7 +215,6 @@ DllExport void* MDD_softingCANConstructor(const char* deviceName, int baudRate) 
 					ACCEPT_CODE_XTD_1);
 	if (ret) {
 		ModelicaFormatError("%s",descriptiveError(ret, "CANL2_set_acceptance"));
-		exit(ret);
 	}
 	ModelicaFormatMessage("\tOK.\n");
 
@@ -227,7 +222,6 @@ DllExport void* MDD_softingCANConstructor(const char* deviceName, int baudRate) 
 	ret = CANL2_set_output_control(mDDSoftingCAN->can, OUTPUT_CONTROL_1);
 	if(ret) {
 		ModelicaFormatError("%s",descriptiveError(ret, "CANL2_set_output_control"));
-		exit(ret);
 	}
 	ModelicaFormatMessage("\tOK.\n");
 
@@ -235,7 +229,6 @@ DllExport void* MDD_softingCANConstructor(const char* deviceName, int baudRate) 
 	ret = CANL2_enable_dyn_obj_buf(mDDSoftingCAN->can);
 	if(ret) {
 		ModelicaFormatError("%s",descriptiveError(ret, "CANL2_enable_dyn_obj_buf"));
-		exit(ret);
 	}
 	ModelicaFormatMessage("\tOK.\n");
 
@@ -243,7 +236,6 @@ DllExport void* MDD_softingCANConstructor(const char* deviceName, int baudRate) 
 	ret = CANL2_initialize_interface(mDDSoftingCAN->can, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0);
 	if(ret) {
 		ModelicaFormatError("%s",descriptiveError(ret, "CANL2_initialize_interface"));
-		exit(ret);
 	}
 	ModelicaFormatMessage("\tOK.\n");
 
@@ -280,7 +272,6 @@ DllExport int MDD_softingCANDefineObject(void* p_mDDSoftingCAN, int ident, int t
 						type - 1, 0, 0, 1);
 	if (ret) {
 		ModelicaFormatError("%s",descriptiveError(ret, "CANL2_define_object"));
-		exit(ret);
 	}
 	switch (type) {
 	case 1:
@@ -296,8 +287,7 @@ DllExport int MDD_softingCANDefineObject(void* p_mDDSoftingCAN, int ident, int t
 		strcpy(msgtype, "ext tx");
 		break;
 	default:
-		ModelicaFormatError("SoftingCAN: Unsupported message type. Exiting.\n");
-		exit(-1);
+		ModelicaFormatError("SoftingCAN: Unsupported message type.\n");
 	}
 
 	ModelicaFormatMessage("SoftingCAN (%s): Defined %s message, id %d (0x%x). Got object number %d.\n",
@@ -314,7 +304,6 @@ DllExport void MDD_softingCANWriteObject(void* p_mDDSoftingCAN, int objectNumber
 				 (unsigned char*) data);
 	if(ret) {
 		ModelicaFormatMessage("%s", descriptiveError(ret, "CANL2_write_object"));
-	    exit(ret);
 	}
 }
 
@@ -361,7 +350,6 @@ DllExport const char* MDD_softingCANReadRcvData(void* p_mDDSoftingCAN, int objec
 	    ModelicaFormatError("RCV Remote: CAN%lu Ident0x%lX  Obj0x%x  Time%lu\n",
 		       mDDSoftingCAN->can, -100, objectNumber, Time);
 	    ModelicaFormatError("Error: Received remote frame instead of data frame, CANL2_read_rcv()\n");
-	    exit(-1);
 	default:
 	    break;
 	}
@@ -378,7 +366,6 @@ DllExport void MDD_softingCANStartChip(void* p_mDDSoftingCAN) {
 	ret = CANL2_start_chip(mDDSoftingCAN->can);
 	if(ret) {
 		ModelicaFormatError("%s",descriptiveError(ret, "CANL2_start_chip"));
-		exit(ret);
 	}
 	ModelicaFormatMessage("\tOK.\n");
 }

--- a/Resources/Include/MDDUDPSocket.h
+++ b/Resources/Include/MDDUDPSocket.h
@@ -202,8 +202,7 @@ int MDD_udpReceivingThread(void * p_udp) {
                         break;
                 case 1: /* new data available */
                         if(sock_poll.revents & POLLHUP) {
-                                ModelicaMessage("The UDP socket was disconnected. Exiting.\n");
-                                exit(1);
+                                ModelicaMessage("The UDP socket was disconnected.\n");
                         } else {
                                 /* Lock acces to udp->msgInternal  */
 				pthread_mutex_lock(&(udp->messageMutex));
@@ -225,8 +224,7 @@ int MDD_udpReceivingThread(void * p_udp) {
                                 break;
                         }
                 default:
-                        ModelicaFormatError("MDDUDPSocket.h: Poll returned %d. That should not happen. Exiting\n", ret);
-                        exit(1);
+                        ModelicaFormatError("MDDUDPSocket.h: Poll returned %d. That should not happen.\n", ret);
                 }
 
 	}
@@ -283,8 +281,7 @@ const char * MDD_udpNonBlockingRead(void * p_udp) {
 
 	case 1: /* new data available */
 		if(sock_poll.revents & POLLHUP) {
-			ModelicaMessage("The UDP socket was disconnected. Exiting.\n");
-			exit(1);
+			ModelicaMessage("The UDP socket was disconnected.\n");
 		} else {
 
 			/* Receive the next datagram. */
@@ -305,8 +302,7 @@ const char * MDD_udpNonBlockingRead(void * p_udp) {
 			break;
 		}
 	default:
-		ModelicaFormatError("MDDUDPSocket.h: Poll returned %d. That should not happen. Exiting\n", ret);
-		exit(1);
+		ModelicaFormatError("MDDUDPSocket.h: Poll returned %d. That should not happen.\n", ret);
 	}
 
 	return (const char*) udp->msgExport;
@@ -338,7 +334,6 @@ void MDD_udpSend(void * p_udp, const char * ipAddress, int port,
 	hostlist = gethostbyname(ipAddress);
 	if (hostlist == NULL) {
 		ModelicaFormatError("MDDUDPSocket.h: gethostbyname(..) failed. Unable to resolve %s.\n", ipAddress);
-		exit(1);
 	}
 
 	/* Good, we have an address. However, some sites
@@ -349,7 +344,6 @@ void MDD_udpSend(void * p_udp, const char * ipAddress, int port,
 	if (hostlist->h_addrtype != AF_INET) {
 		ModelicaFormatError("MDDUDPSocket.h: Error, %s doesn’t seem to be an IPv4 address.\n",
 				    ipAddress);
-		exit(1);
 	}
 
 	/* inet_ntop converts a 32-bit IP address to
@@ -384,7 +378,6 @@ void MDD_udpSend(void * p_udp, const char * ipAddress, int port,
 		ModelicaFormatError("MDDUDPSocket.h: Expected to send: %d bytes, but was: %d\n"
 				    "sendto(..) failed (%s)\n", dataSize, ret, strerror(errno));
 		MDD_udpDestructor((void *) udp);
-		exit(1);
 	}
 
 }
@@ -415,7 +408,6 @@ void * MDD_udpConstructor(int port, int bufferSize) {
 	if (ret != 0) {
 		ModelicaFormatError("MDDUDPSocket.h: pthread_mutex_init() failed (%s)\n",
 				    strerror(errno));
-		exit(1);
 	}
 
 	/* Create a SOCK_DGRAM socket. */
@@ -423,7 +415,6 @@ void * MDD_udpConstructor(int port, int bufferSize) {
 	if (udp->sock < 0) {
 		ModelicaFormatError("MDDUDPSocket.h: socket(..) failed (%s)\n",
 				    strerror(errno));
-		exit(1);
 	}
 	ModelicaFormatMessage("Created socket handle: %d (%s socket)\n",
 			      udp->sock, port == 0 ? "sending" : "receiving");
@@ -451,7 +442,6 @@ void * MDD_udpConstructor(int port, int bufferSize) {
 			ModelicaFormatError("MDDUDPSocket.h: bind(..) failed (%s)\n",
 					    port,
 					    strerror(errno));
-			exit(1);
 		}
 
 		/* Start dedicated receiver thread */
@@ -459,7 +449,6 @@ void * MDD_udpConstructor(int port, int bufferSize) {
 		ret = pthread_create(&udp->thread, 0, (void *) MDD_udpReceivingThread, udp);
 		if (ret) {
 			ModelicaFormatError("MDDUDPSocket: pthread(..) failed\n");
-			exit (1);
 		}
 	}
 

--- a/Resources/test/Util/ModelicaUtilities.c
+++ b/Resources/test/Util/ModelicaUtilities.c
@@ -23,6 +23,7 @@ void ModelicaFormatMessage(const char *string,...) {
 
 void ModelicaError(const char *string) {
    fprintf (stderr, "%s", string);
+   exit(1);
 }
 
 
@@ -31,6 +32,7 @@ void ModelicaFormatError(const char *string,...) {
    va_start(p_arg,string);
    vfprintf(stderr, string,p_arg);
    va_end(p_arg);
+   exit(1);
 }
 
 


### PR DESCRIPTION
According to MLS 3.2 rev2 section 12.9.6 the functions ModelicaError and ModelicaFormatError never return to the calling function. That's why there is no need to call exit or dtor after these error function. Also calling exit during a simulation is not desired at all as it would kill the simulator application.

For the same reason the exit call was added to the test implementation of the ModelicaUtilities.c.