### PR TITLE
Rename ifr_name to ifrName

### DIFF
--- a/Modelica_DeviceDrivers/Blocks/Communication.mo
+++ b/Modelica_DeviceDrivers/Blocks/Communication.mo
@@ -559,14 +559,14 @@ not necessary mean that your Modelica tool compiles 64bit binaries, i.e., if in 
     record SocketCANConfig "Open socket to specified CAN interface"
     extends Modelica_DeviceDrivers.Utilities.Icons.SocketCANRecordIcon;
       import Modelica_DeviceDrivers.Communication.SocketCAN;
-      parameter String ifr_name = "vcan0"
+      parameter String ifrName = "vcan0"
         "CAN interface name (as displayed by ifconfig)";
-      final parameter SocketCAN dh = SocketCAN(ifr_name) "SocketCAN handle";
+      final parameter SocketCAN dh = SocketCAN(ifrName) "SocketCAN handle";
       annotation (preferredView="info",
               Icon(graphics={
                      Text(
               extent={{-98,70},{98,42}},
-              textString="%ifr_name")}),
+              textString="%ifrName")}),
         Documentation(info="<html>
 <h4><font color=\"#008000\">Support for Linux Socket CAN bus</font></h4>
 <p><b>Please, read the package information for <a href=\"modelica://Modelica_DeviceDrivers.Blocks.Communication.SocketCAN\"><code>SocketCAN</code></a> first!</b></p>

--- a/Modelica_DeviceDrivers/Blocks/Examples/TestSerialPackager_SocketCAN.mo
+++ b/Modelica_DeviceDrivers/Blocks/Examples/TestSerialPackager_SocketCAN.mo
@@ -3,7 +3,7 @@ model TestSerialPackager_SocketCAN
     extends Modelica.Icons.Example;
 
   import Modelica_DeviceDrivers;
-  Modelica_DeviceDrivers.Blocks.Communication.SocketCAN.SocketCANConfig socketCANConfig1(ifr_name=
+  Modelica_DeviceDrivers.Blocks.Communication.SocketCAN.SocketCANConfig socketCANConfig1(ifrName=
         "vcan0")
     annotation (Placement(transformation(extent={{-70,40},{-50,60}})));
   Modelica_DeviceDrivers.Blocks.Communication.SocketCAN.WriteMessage txMessage(
@@ -36,7 +36,7 @@ model TestSerialPackager_SocketCAN
     annotation (Placement(transformation(extent={{20,4},{40,24}})));
   Modelica_DeviceDrivers.Blocks.Packaging.SerialPackager.GetInteger getInteger(
       nu=1) annotation (Placement(transformation(extent={{20,-22},{40,-2}})));
-  Modelica_DeviceDrivers.Blocks.Communication.SocketCAN.SocketCANConfig socketCANConfig2(ifr_name=
+  Modelica_DeviceDrivers.Blocks.Communication.SocketCAN.SocketCANConfig socketCANConfig2(ifrName=
         "vcan0")
     annotation (Placement(transformation(extent={{-6,40},{14,60}})));
   Modelica_DeviceDrivers.Blocks.Packaging.SerialPackager.UnpackUnsignedInteger

--- a/Modelica_DeviceDrivers/Communication/SocketCAN.mo
+++ b/Modelica_DeviceDrivers/Communication/SocketCAN.mo
@@ -4,10 +4,10 @@ class SocketCAN
 extends ExternalObject;
 encapsulated function constructor "Open Socket / Create external object"
     import Modelica_DeviceDrivers.Communication.SocketCAN;
-input String ifr_name;
+input String ifrName;
 output SocketCAN softingCAN;
 
-  external "C" softingCAN = MDD_socketCANConstructor(ifr_name)
+  external "C" softingCAN = MDD_socketCANConstructor(ifrName)
   annotation (IncludeDirectory="modelica://Modelica_DeviceDrivers/Resources/Include",
     Include="#include \"MDDSocketCAN.h\"",
               Library={"pthread"});


### PR DESCRIPTION
SimulationX generates for record Modelica_DeviceDrivers.Blocks.Communication.SocketCAN.SocketCANConfig the following typedef struct in C code
```c
typedef struct Modelica_DeviceDrivers_Blocks_Communication_SocketCAN_SocketCANConfig
{
	void* dh;
	ITI_char* ifr_name;
}Modelica_DeviceDrivers_Blocks_Communication_SocketCAN_SocketCANConfig;
```
but there is
```c
# define ifr_name	ifr_ifrn.ifrn_name	/* interface name 	*/
```
in /usr/include/net/if.h finally resulting in invalid C code. Renaming ifr_name avoids this name clash.

@bernhard-thiele Please confirm and merge!