### PR TITLE
Keep read data instead of discarding on receive

### DIFF
--- a/Modelica_DeviceDrivers/Resources/Include/MDDSerialPort.h
+++ b/Modelica_DeviceDrivers/Resources/Include/MDDSerialPort.h
@@ -577,10 +577,10 @@ void* MDD_serialPortReceivingThread(void * p_serial) {
                     /* Lock acces to serial->receiveBuffer */
                     pthread_mutex_lock(&(serial->receiveMutex));
                     /* Receive the next datagram */
-                    serial->receivedBytes =
+                    serial->receivedBytes +=
                         read(serial->fd, /* serial port file handle*/
-                             serial->receiveBuffer, /* receive buffer */
-                             serial->bufferSize /* max bytes to receive */
+                             serial->receiveBuffer+serial->receivedBytes, /* receive buffer */
+                             serial->bufferSize-serial->receivedBytes /* max bytes to receive */
                             );
                     pthread_mutex_unlock(&(serial->receiveMutex));
 


### PR DESCRIPTION
This partially fixes #117 (there is still the problem that reading
data discards the entire buffer).