### PR TITLE
Use loadResource instead classDirectory()

### DIFF
--- a/Modelica_DeviceDrivers/Incubate/Examples/TestLoadRealParameter.mo
+++ b/Modelica_DeviceDrivers/Incubate/Examples/TestLoadRealParameter.mo
@@ -2,11 +2,12 @@ within Modelica_DeviceDrivers.Incubate.Examples;
 model TestLoadRealParameter
 extends Modelica.Icons.Example;
   import Modelica_DeviceDrivers.Utilities.Functions.*;
+  import Modelica;
   parameter Real var1 = loadRealParameter(
-   Modelica_DeviceDrivers.Utilities.RootDir+"/Resources/test/Util/parameterInitValues.txt", "var1");
+   Modelica.Utilities.Files.loadResource("modelica://Modelica_DeviceDrivers/Resources/test/Util/parameterInitValues.txt"), "var1");
   parameter Integer n = 3 "Size of arrayvar";
   parameter Real arrayvar[n] = loadRealParameterVector(
-   Modelica_DeviceDrivers.Utilities.RootDir+"/Resources/test/Util/parameterInitValues.txt", "arrayvar", n);
+   Modelica.Utilities.Files.loadResource("modelica://Modelica_DeviceDrivers/Resources/test/Util/parameterInitValues.txt"), "arrayvar", n);
 equation
   when sample(0, 0.1) then
     Modelica.Utilities.Streams.print("var1: "+String(var1));

--- a/Modelica_DeviceDrivers/Utilities/Functions.mo
+++ b/Modelica_DeviceDrivers/Utilities/Functions.mo
@@ -17,7 +17,7 @@ package Functions
 <p>The function expects a file format in the style <code>&quot;identifier=value&quot;</code>.</p>
 <h4><font color=\"#008000\">Example</font></h4>
 <p>Consider following example file and assume it's saved under location<br/>
-<code>Modelica_DeviceDrivers.Utilities.RootDir+&quot;/Resources/test/Util/parameterInitValues.txt&quot;</code>:</p>
+<code>&quot;modelica://Modelica_DeviceDrivers/Resources/test/Util/parameterInitValues.txt&quot;</code>:</p>
 <pre>
 arrayvar_1=0.1
 arrayvar_2=0.2
@@ -30,10 +30,10 @@ model TestLoadRealParameter
 extends Modelica.Icons.Example;
   import Modelica_DeviceDrivers.Utilities.Functions.*;
   parameter Real var1 = loadRealParameter(
-   Modelica_DeviceDrivers.Utilities.RootDir+\"/Resources/test/Util/parameterInitValues.txt\", \"var1\");
+   Modelica.Utilities.Files.loadResource(\"modelica://Modelica_DeviceDrivers/Resources/test/Util/parameterInitValues.txt\"), \"var1\");
   parameter Integer n = 3 \"Size of arrayvar\";
   parameter Real arrayvar[n] = loadRealParameterVector(
-   Modelica_DeviceDrivers.Utilities.RootDir+\"/Resources/test/Util/parameterInitValues.txt\", \"arrayvar\", n);
+   Modelica.Utilities.Files.loadResource(\"modelica://Modelica_DeviceDrivers/Resources/test/Util/parameterInitValues.txt\"), \"arrayvar\", n);
 equation
   when sample(0, 0.1) then
     Modelica.Utilities.Streams.print(\"var1: \"+String(var1));

--- a/Modelica_DeviceDrivers/Utilities/package.mo
+++ b/Modelica_DeviceDrivers/Utilities/package.mo
@@ -1,8 +1,6 @@
 within Modelica_DeviceDrivers;
 package Utilities "Collection of utility elements used within the library"
   extends Modelica.Icons.UtilitiesPackage;
-  constant String RootDir=Modelica.Utilities.Files.fullPathName(classDirectory() + "..");
-
   annotation (
    preferredView="info",
    Documentation(info="<html>

--- a/Modelica_DeviceDrivers/Utilities/package.order
+++ b/Modelica_DeviceDrivers/Utilities/package.order
@@ -1,4 +1,3 @@
-RootDir
 Functions
 Icons
 Types


### PR DESCRIPTION
The classDirectory function was previously used in MSL, but was never
standardized. Instead, the loadResource function was added. This commit
removes the usage of the old classDirectory functionality and removes
the rootDir constant, since it is nicer to just access the modelica://
URIs directly in the given locations.

This resolves #159 