### PR TITLE
Change extends model to conform to the spec

### DIFF
--- a/Modelica_DeviceDrivers/EmbeddedTargets/AVR/Functions/Digital/InitRead.mo
+++ b/Modelica_DeviceDrivers/EmbeddedTargets/AVR/Functions/Digital/InitRead.mo
@@ -1,5 +1,5 @@
 within Modelica_DeviceDrivers.EmbeddedTargets.AVR.Functions.Digital;
-model InitRead
+class InitRead
 extends ExternalObject;
 function constructor "Initialize device"
   import Modelica_DeviceDrivers.EmbeddedTargets.AVR.{Constants,Types};

--- a/Modelica_DeviceDrivers/Utilities/Icons/GenericIC.mo
+++ b/Modelica_DeviceDrivers/Utilities/Icons/GenericIC.mo
@@ -1,5 +1,5 @@
 within Modelica_DeviceDrivers.Utilities.Icons;
-partial model GenericIC "Icon with a generic IC"
+partial block GenericIC "Icon with a generic IC"
   annotation(Icon(coordinateSystem(preserveAspectRatio = true, extent = {{-100, -100}, {100, 100}}), graphics = {Bitmap(extent = {{-95, -95}, {95, 95}}, fileName = "modelica://Modelica_DeviceDrivers/Resources/Images/Icons/tqfp32.png", rotation = 0)}), Documentation(info = "<html>
 <p>
 This partial class is intended to design a <em>default icon for microcontrollers</em>.


### PR DESCRIPTION
External objects must be `class` and the base generic IC icon can be a
`block` instead of `model` to allow more kinds to inherit from it.

This partially resolves #170.