### PR TITLE
Avoid passing initial() to wait()

### DIFF
--- a/Modelica_DeviceDrivers/EmbeddedTargets/AVR/Blocks/SynchronizeRealtime.mo
+++ b/Modelica_DeviceDrivers/EmbeddedTargets/AVR/Blocks/SynchronizeRealtime.mo
@@ -35,6 +35,8 @@ protected
   Functions.Timers.Timer clock = Functions.Timers.Timer(timer, prescaler, clearTimerOnMatch=false);
   Functions.RealTimeSynchronization.Init sync = Functions.RealTimeSynchronization.Init(clock, count, iterations);
 algorithm
-  Functions.RealTimeSynchronization.wait(sync, initial());
+  if not initial() then
+    Functions.RealTimeSynchronization.wait(sync);
+  end if;
 annotation(Icon(graphics = {Text(extent = {{-100, -100}, {100, 100}}, textString = "Real-time:\n%desiredFrequency Hz", fontName = "Arial")}, coordinateSystem(initialScale = 0.1)));
 end SynchronizeRealtime;

--- a/Modelica_DeviceDrivers/EmbeddedTargets/AVR/Functions/RealTimeSynchronization.mo
+++ b/Modelica_DeviceDrivers/EmbeddedTargets/AVR/Functions/RealTimeSynchronization.mo
@@ -4,8 +4,7 @@ extends .Modelica.Icons.Package;
 
 function wait
   input Init rt;
-  input Boolean isInitial = initial();
-  external "C" MDD_avr_rt_wait(rt, isInitial)
+  external "C" MDD_avr_rt_wait(rt)
   annotation (Include="#include \"MDDAVRRealTime.h\"");
 end wait;
 

--- a/Modelica_DeviceDrivers/Resources/Include/MDDAVRRealTime.h
+++ b/Modelica_DeviceDrivers/Resources/Include/MDDAVRRealTime.h
@@ -66,11 +66,8 @@ static volatile uint16_t numInterruptTriggered=0;
 /* The wait routine actually starts the clock.
  * This is done after initialization to avoid weird behaviour
  */
-static inline void MDD_avr_rt_wait(void *timer, int isInitial)
+static inline void MDD_avr_rt_wait(void *timer)
 {
-  if (isInitial) {
-    return;
-  }
   switch ((int)timer) {
 #if defined(__AVR_ATmega16__)
   case 1:


### PR DESCRIPTION
SimulationX complains if initial() is passed to a function.

This is anyway a good idea since the real-time synchronization block can
take perform this check instead of the external function.

This partially resolves #170.