### PR TITLE
Remove bad LinePattern.None

### DIFF
--- a/Modelica_DeviceDrivers/ClockedBlocks/Interfaces.mo
+++ b/Modelica_DeviceDrivers/ClockedBlocks/Interfaces.mo
@@ -15,8 +15,7 @@ package Interfaces
           initialScale=0.2), graphics={Rectangle(
             extent={{-100,40},{100,-40}},
             fillColor={255,255,0},
-            fillPattern=FillPattern.Sphere,
-            pattern=LinePattern.None),
+            fillPattern=FillPattern.Sphere),
           Line(
             points={{-100,-40},{0,40},{100,-40}},
             color={95,95,95}),
@@ -41,8 +40,7 @@ package Interfaces
           initialScale=0.2), graphics={Rectangle(
             extent={{-100,40},{100,-40}},
             fillColor={255,255,0},
-            fillPattern=FillPattern.Sphere,
-            pattern=LinePattern.None),
+            fillPattern=FillPattern.Sphere),
           Line(
             points={{-100,40},{0,-40},{100,40}},
             color={95,95,95}),


### PR DESCRIPTION
Follow up of d2de0bb0a25afae3f198e704e704691499ec0988. SimulationX draws invisible connection lines otherwise.