### PR TITLE
UDPReceive blocks enhancements. Closes #236

### DIFF
--- a/Modelica_DeviceDrivers/ClockedBlocks/Communication.mo
+++ b/Modelica_DeviceDrivers/ClockedBlocks/Communication.mo
@@ -133,13 +133,17 @@ provided by the parameter <b>memoryID</b>. If the shared memory partition does n
     parameter Integer port_recv=10001
       "Listening port number of the server. Must be unique on the system"
       annotation (Dialog(group="Incoming data"));
+    parameter Boolean showReceivedBytesPort = false "=true, if number of received bytes port is visible" annotation(Dialog(tab="Advanced"),Evaluate=true, HideResult=true, choices(checkBox=true));
 
     Interfaces.PackageOut pkgOut  annotation (Placement(
           transformation(
           extent={{-20,-20},{20,20}},
           rotation=90,
           origin={108,0})));
-
+     Modelica.Blocks.Interfaces.IntegerOutput nRecvBytes
+       "Number of received bytes" annotation (Placement(visible=
+             showReceivedBytesPort, transformation(extent={{100,70},{120,90}})));
+     output Integer nRecvbufOverwrites "Accumulated number of times new data was received without having been read out (retrieved) by Modelica";
   protected
     Integer bufferSize;
     UDPSocket socket;
@@ -164,7 +168,7 @@ provided by the parameter <b>memoryID</b>. If the shared memory partition does n
 
     dummy = previous(dummy) + Ts;
 
-    pkgOut.dummy = Modelica_DeviceDrivers.ClockedBlocks.Communication.Internal.DummyFunctions.readUDP(
+    (pkgOut.dummy,nRecvBytes,nRecvbufOverwrites) = Modelica_DeviceDrivers.ClockedBlocks.Communication.Internal.DummyFunctions.readUDP(
       socket,
       pkgOut.pkg,
       dummy);
@@ -260,8 +264,11 @@ provided by the parameter <b>memoryID</b>. If the shared memory partition does n
         input Modelica_DeviceDrivers.Packaging.SerialPackager pkg;
         input Real dummy;
         output Real dummy2;
+        output Integer nRecvBytes;
+        output Integer nRecvbufOverwrites;
       algorithm
-        Modelica_DeviceDrivers.Communication.UDPSocket_.read(socket, pkg);
+        (nRecvBytes, nRecvbufOverwrites) :=
+          Modelica_DeviceDrivers.Communication.UDPSocket_.read(socket, pkg);
         dummy2 := dummy;
       end readUDP;
 

--- a/Modelica_DeviceDrivers/Communication/UDPSocket_.mo
+++ b/Modelica_DeviceDrivers/Communication/UDPSocket_.mo
@@ -8,7 +8,9 @@ package UDPSocket_ "Accompanying functions for the UDPSocket object"
     import Modelica_DeviceDrivers.Packaging.SerialPackager;
     input UDPSocket socket;
     input SerialPackager pkg;
-    external "C" MDD_udpReadP(socket, pkg)
+    output Integer nReceivedBytes "Number of received bytes";
+    output Integer nRecvbufOverwrites "Accumlated number of times new data was received without having been read out (retrieved) by Modelica";
+    external "C" MDD_udpReadP(socket, pkg, nReceivedBytes, nRecvbufOverwrites)
     annotation(Include = "#include \"MDDUDPSocket.h\"",
            Library = {"pthread", "Ws2_32"},
            __iti_dll = "ITI_MDD.dll",


### PR DESCRIPTION
1. Additional output nRecvBytes. Output is not visible on diagram layer
as default, but can be made visible by a parameter in the "Advanced" tab.
2. Additional output nRecvbufOverwrites.