### PR TITLE
Fix CompatibilityDefs.h

### DIFF
--- a/Modelica_DeviceDrivers/Resources/src/ITI_ModelicaDeviceDrivers/MDDLCMWrapper.c
+++ b/Modelica_DeviceDrivers/Resources/src/ITI_ModelicaDeviceDrivers/MDDLCMWrapper.c
@@ -6,4 +6,7 @@
  *
  *
 */
+
+#define ITI_MDD
+#define MDDSHAREDLIBRARY
 #include "../../Include/MDDLCM.h"

--- a/Modelica_DeviceDrivers/Resources/src/ITI_ModelicaDeviceDrivers/MDDSoftingCANWrapper.c
+++ b/Modelica_DeviceDrivers/Resources/src/ITI_ModelicaDeviceDrivers/MDDSoftingCANWrapper.c
@@ -6,5 +6,8 @@
  *
  *
 */
+
 #define MDDSOFTINGCANUSECMAKE
+#define ITI_MDD
+#define MDDSHAREDLIBRARY
 #include "../../Include/MDDSoftingCAN.h"

--- a/Modelica_DeviceDrivers/Resources/src/ITI_ModelicaDeviceDrivers/MDDWrapper.c
+++ b/Modelica_DeviceDrivers/Resources/src/ITI_ModelicaDeviceDrivers/MDDWrapper.c
@@ -20,6 +20,7 @@
 */
 
 #define ITI_MDD
+#define MDDSHAREDLIBRARY
 #include "../../Include/MDDBeep.h"
 #include "../../Include/MDDJoystick.h"
 #include "../../Include/MDDKeyboard.h"
@@ -33,4 +34,3 @@
 #include "../../Include/MDDUtilitiesMAC.h"
 #include "../../Include/MDDUtilitiesUUID.h"
 #include "../../Include/MDDTCPIPSocket.h"
-#undef ITI_MDD

--- a/Modelica_DeviceDrivers/Resources/src/include/CompatibilityDefs.h
+++ b/Modelica_DeviceDrivers/Resources/src/include/CompatibilityDefs.h
@@ -37,14 +37,14 @@
 #define COMPATIBILITYDEFS_H_
 
 /* Compile dll and so from same source */
-#if defined(_MSC_VER) && !defined(ITI_CE_EXEC_MODEL)
+#if defined(_MSC_VER) && defined(MDDSHAREDLIBRARY)
 # define DllImport \
 __declspec( dllimport )
 # define DllExport \
 __declspec( dllexport )
 #else
 # define DllImport
-# define DllExport
+# define DllExport static
 #endif /*_MSC_VER */
 # define EXTERN DllImport extern
 

--- a/Modelica_DeviceDrivers/Resources/src/include/CompatibilityDefs.h
+++ b/Modelica_DeviceDrivers/Resources/src/include/CompatibilityDefs.h
@@ -44,11 +44,11 @@
 # else
 #  define DllImport
 #  define DllExport
-# endif
+# endif /* _MSC_VER */
 #else
 # define DllImport
 # define DllExport static
-#endif /*_MSC_VER */
+#endif /* MDDSHAREDLIBRARY */
 # define EXTERN DllImport extern
 
 /* Some definitions necessary in order to use <windows.h> in Dymola,

--- a/Modelica_DeviceDrivers/Resources/src/include/CompatibilityDefs.h
+++ b/Modelica_DeviceDrivers/Resources/src/include/CompatibilityDefs.h
@@ -37,11 +37,14 @@
 #define COMPATIBILITYDEFS_H_
 
 /* Compile dll and so from same source */
-#if defined(_MSC_VER) && defined(MDDSHAREDLIBRARY)
-# define DllImport \
-__declspec( dllimport )
-# define DllExport \
-__declspec( dllexport )
+#if defined(MDDSHAREDLIBRARY)
+# if defined(_MSC_VER)
+#  define DllImport __declspec( dllimport )
+#  define DllExport __declspec( dllexport )
+# else
+#  define DllImport
+#  define DllExport
+# endif
 #else
 # define DllImport
 # define DllExport static


### PR DESCRIPTION
* Only export symbols if `MDDSHAREDLIBRARY` is set explicitly. This is the case for the SimulationX specific wrappers.
* Can set `DllExport` to `static` otherwise to avoid a potential linker issue with inclusion by multiple modules